### PR TITLE
Collections force encapsulation

### DIFF
--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1052,25 +1052,23 @@ namespace kOS.Safe.Compilation
 
             if (scalarValue != null && scalarValue.IsValid)
             {
-                    scalarValue = -scalarValue;
-            }
-            else
-            {
-                // Generic last-ditch to catch any sort of object that has
-                // overloaded the unary negate operator '-'.
-                // (For example, kOS.Suffixed.Vector and kOS.Suffixed.Direction)
-                Type t = value.GetType();
-                MethodInfo negateMe = t.GetMethod("op_UnaryNegation", BindingFlags.FlattenHierarchy |BindingFlags.Static | BindingFlags.Public); // C#'s alternate name for '-' operator
-                if (negateMe != null)
-                {
-                    object result = negateMe.Invoke(null, new[]{value});
-                    scalarValue = ScalarValue.Create(result);
-                }
-                else
-                    throw new KOSUnaryOperandTypeException("negate", value);
+                cpu.PushStack(-scalarValue);
+                return;
             }
 
-            cpu.PushStack(scalarValue);
+            // Generic last-ditch to catch any sort of object that has
+            // overloaded the unary negate operator '-'.
+            // (For example, kOS.Suffixed.Vector and kOS.Suffixed.Direction)
+            Type t = value.GetType();
+            MethodInfo negateMe = t.GetMethod("op_UnaryNegation", BindingFlags.FlattenHierarchy |BindingFlags.Static | BindingFlags.Public);
+            if (negateMe != null)
+            {
+                object result = negateMe.Invoke(null, new[]{value});
+                cpu.PushStack(result);
+            }
+            else
+                throw new KOSUnaryOperandTypeException("negate", value);
+
         }
     }
 

--- a/src/kOS.Safe/Compilation/Opcode.cs
+++ b/src/kOS.Safe/Compilation/Opcode.cs
@@ -1379,9 +1379,9 @@ namespace kOS.Safe.Compilation
             // If it's a string it might not really be a built-in, it might still be a user func.
             // Detect whether it's built-in, and if it's not, then convert it into the equivalent
             // user func call by making it be an integer instruction pointer instead:
-            if (functionPointer is string)
+            if (functionPointer is string || functionPointer is StringValue)
             {
-                string functionName = functionPointer as string;
+                string functionName = functionPointer.ToString();
                 if (functionName.EndsWith("()"))
                     functionName = functionName.Substring(0, functionName.Length - 2);
                 if (!(cpu.BuiltInExists(functionName)))

--- a/src/kOS.Safe/Encapsulation/EnumerableValue.cs
+++ b/src/kOS.Safe/Encapsulation/EnumerableValue.cs
@@ -41,7 +41,7 @@ namespace kOS.Safe.Encapsulation
             return new SafeSerializationMgr().ToString(this);
         }
 
-        public IDictionary<Structure, Structure> Dump()
+        public IDictionary<object, object> Dump()
         {
             var result = new DictionaryWithHeader
             {
@@ -59,7 +59,7 @@ namespace kOS.Safe.Encapsulation
             return result;
         }
 
-        public abstract void LoadDump(IDictionary<Structure, Structure> dump);
+        public abstract void LoadDump(IDictionary<object, object> dump);
 
         private void InitializeEnumerableSuffixes()
         {

--- a/src/kOS.Safe/Encapsulation/IDumper.cs
+++ b/src/kOS.Safe/Encapsulation/IDumper.cs
@@ -14,7 +14,7 @@ namespace kOS.Safe.Encapsulation
     /// </summary>
     public interface IDumper : ISuffixed
     {
-        IDictionary<Structure, Structure> Dump();
-        void LoadDump(IDictionary<Structure, Structure> dump);
+        IDictionary<object, object> Dump();
+        void LoadDump(IDictionary<object, object> dump);
     }
 }

--- a/src/kOS.Safe/Encapsulation/IIndexable.cs
+++ b/src/kOS.Safe/Encapsulation/IIndexable.cs
@@ -3,6 +3,8 @@ namespace kOS.Safe.Encapsulation
     public interface IIndexable
     {
         Structure GetIndex(Structure index);
+        Structure GetIndex(int index);
         void SetIndex(Structure index, Structure value);
+        void Structure SetIndex(int index, Structure value);
     }
 }

--- a/src/kOS.Safe/Encapsulation/IIndexable.cs
+++ b/src/kOS.Safe/Encapsulation/IIndexable.cs
@@ -3,8 +3,26 @@ namespace kOS.Safe.Encapsulation
     public interface IIndexable
     {
         Structure GetIndex(Structure index);
-        Structure GetIndex(int index);
         void SetIndex(Structure index, Structure value);
-        void Structure SetIndex(int index, Structure value);
+
+        /// <summary>
+        /// This should redirect to GetIndex(Structure index), and is provided as 
+        /// a convenient shorthand for GetIndex(Structure.FromPrimitive(someInt)),
+        /// because of the large number of places in the code that were written to
+        /// assume integer indeces:
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        Structure GetIndex(int index);
+
+        /// <summary>
+        /// This should redirect to SetIndex(Structure index, Structure value), and is provided as 
+        /// a convenient shorthand for SetIndex(Structure.FromPrimitive(someInt), someValue)
+        /// because of the large number of places in the code that were written to
+        /// assume integer indeces:
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        void SetIndex(int index, Structure value);
     }
 }

--- a/src/kOS.Safe/Encapsulation/Lexicon.cs
+++ b/src/kOS.Safe/Encapsulation/Lexicon.cs
@@ -219,9 +219,23 @@ namespace kOS.Safe.Encapsulation
             return internalDictionary[key];
         }
 
+        // Only needed because IIndexable demands it.  For a lexicon, none of the code is
+        // actually trying to call this:
+        public Structure GetIndex(int index)
+        {
+            return internalDictionary[Structure.FromPrimitive(index)];
+        }
+
         public void SetIndex(Structure index, Structure value)
         {
             internalDictionary[index] = value;
+        }
+        
+        // Only needed because IIndexable demands it.  For a lexicon, none of the code is
+        // actually trying to call this:
+        public void SetIndex(int index, Structure value)
+        {
+            internalDictionary[Structure.FromPrimitive(index)] = value;
         }
 
         public override string ToString()
@@ -229,9 +243,9 @@ namespace kOS.Safe.Encapsulation
             return new SafeSerializationMgr().ToString(this);
         }
 
-        public IDictionary<Structure, Structure> Dump()
+        public IDictionary<object, object> Dump()
         {
-            var result = new DictionaryWithHeader((Dictionary<Structure, Structure>)internalDictionary)
+            var result = new DictionaryWithHeader((Dictionary<object, object>)internalDictionary)
             {
                 Header = "LEXICON of " + internalDictionary.Count + " items:"
             };
@@ -239,11 +253,11 @@ namespace kOS.Safe.Encapsulation
             return result;
         }
 
-        public void LoadDump(IDictionary<Structure, Structure> dump)
+        public void LoadDump(IDictionary<object, object> dump)
         {
             internalDictionary.Clear();
 
-            foreach (KeyValuePair<Structure, Structure> entry in dump)
+            foreach (KeyValuePair<object, object> entry in dump)
             {
                 internalDictionary.Add(Structure.FromPrimitive(entry.Key), Structure.FromPrimitive(entry.Value));
             }

--- a/src/kOS.Safe/Encapsulation/ListValue.cs
+++ b/src/kOS.Safe/Encapsulation/ListValue.cs
@@ -57,7 +57,7 @@ namespace kOS.Safe.Encapsulation
             set { Collection[index] = value; }
         }
             
-        public override void LoadDump(IDictionary<Structure, Structure> dump)
+        public override void LoadDump(IDictionary<object, object> dump)
         {
             Collection.Clear();
 
@@ -124,6 +124,12 @@ namespace kOS.Safe.Encapsulation
         }
 
 
+        public void SetIndex(int index, Structure value)
+        {
+            Collection[index] = (T)value;
+        }
+
+
     }
 
     public class ListValue : ListValue<Structure>
@@ -146,7 +152,7 @@ namespace kOS.Safe.Encapsulation
 
         public new static ListValue CreateList<T>(IEnumerable<T> toCopy)
         {
-            return new ListValue(toCopy.Cast<object>());
+            return new ListValue(toCopy.Select(x => Structure.FromPrimitive(x)));
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/QueueValue.cs
+++ b/src/kOS.Safe/Encapsulation/QueueValue.cs
@@ -5,6 +5,7 @@ using kOS.Safe.Encapsulation.Suffixes;
 namespace kOS.Safe.Encapsulation
 {
     public class QueueValue<T> : EnumerableValue<T, Queue<T>>
+        where T : Structure
     {
         public QueueValue() : this(new Queue<T>())
         {
@@ -30,7 +31,7 @@ namespace kOS.Safe.Encapsulation
             Collection.Enqueue(val);
         }
             
-        public override void LoadDump(IDictionary<Structure, Structure> dump)
+        public override void LoadDump(IDictionary<object, object> dump)
         {
             Collection.Clear();
 
@@ -57,14 +58,14 @@ namespace kOS.Safe.Encapsulation
 
     }
 
-    public class QueueValue : QueueValue<object>
+    public class QueueValue : QueueValue<Structure>
     {
         public QueueValue()
         {
             InitializeSuffixes();
         }
 
-        public QueueValue(IEnumerable<object> toCopy)
+        public QueueValue(IEnumerable<Structure> toCopy)
             : base(toCopy)
         {
             InitializeSuffixes();
@@ -77,7 +78,7 @@ namespace kOS.Safe.Encapsulation
 
         public new static QueueValue CreateQueue<T>(IEnumerable<T> toCopy)
         {
-            return new QueueValue(toCopy.Cast<object>());
+            return new QueueValue(toCopy.Select(x => Structure.FromPrimitive(x)));
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/StackValue.cs
+++ b/src/kOS.Safe/Encapsulation/StackValue.cs
@@ -5,6 +5,7 @@ using kOS.Safe.Encapsulation.Suffixes;
 namespace kOS.Safe.Encapsulation
 {
     public class StackValue<T> : EnumerableValue<T, Stack<T>>
+        where T : Structure
     {
         public StackValue() : this(new Stack<T>())
         {
@@ -35,7 +36,7 @@ namespace kOS.Safe.Encapsulation
             Collection.Push(val);
         }
 
-        public override void LoadDump(IDictionary<Structure, Structure> dump)
+        public override void LoadDump(IDictionary<object, object> dump)
         {
             Collection.Clear();
 
@@ -62,14 +63,14 @@ namespace kOS.Safe.Encapsulation
         }
     }
 
-    public class StackValue : StackValue<object>
+    public class StackValue : StackValue<Structure>
     {
         public StackValue()
         {
             InitializeSuffixes();
         }
 
-        public StackValue(IEnumerable<object> toCopy)
+        public StackValue(IEnumerable<Structure> toCopy)
             : base(toCopy)
         {
             InitializeSuffixes();
@@ -82,7 +83,7 @@ namespace kOS.Safe.Encapsulation
 
         public new static StackValue CreateStack<T>(IEnumerable<T> toCopy)
         {
-            return new StackValue(toCopy.Cast<object>());
+            return new StackValue(toCopy.Select(x => Structure.FromPrimitive(x)));
         }
     }
 }

--- a/src/kOS.Safe/Encapsulation/StringValue.cs
+++ b/src/kOS.Safe/Encapsulation/StringValue.cs
@@ -148,7 +148,7 @@ namespace kOS.Safe.Encapsulation
             if (index is ScalarValue)
             {
                 int i = Convert.ToInt32(index);  // allow expressions like (1.0) to be indexes
-                return internalString[i].ToString();
+                return new StringValue(internalString[i]);
             }
             throw new KOSCastException(index.GetType(), typeof(int)/*So the message will say it needs integer, not just any Scalar*/);
 
@@ -156,6 +156,11 @@ namespace kOS.Safe.Encapsulation
 
         // Required by the interface but unimplemented, because strings are immutable.
         public void SetIndex(Structure index, Structure value)
+        {
+            throw new KOSException("String are immutable; they can not be modified using the syntax \"SET string[1] TO 'a'\", etc.");
+        }
+        // Required by the interface but unimplemented, because strings are immutable.
+        public void SetIndex(int index, Structure value)
         {
             throw new KOSException("String are immutable; they can not be modified using the syntax \"SET string[1] TO 'a'\", etc.");
         }

--- a/src/kOS.Safe/Encapsulation/Structure.cs
+++ b/src/kOS.Safe/Encapsulation/Structure.cs
@@ -172,7 +172,7 @@ namespace kOS.Safe.Encapsulation
         {
             // No conversion if already encapsulated:
             if (value is Structure)
-                return value;
+                return (Structure)value;
             
             var convert = value as IConvertible;
             if (convert == null)

--- a/src/kOS/AddOns/KerbalAlarmClock/KACFunctions.cs
+++ b/src/kOS/AddOns/KerbalAlarmClock/KACFunctions.cs
@@ -53,14 +53,14 @@ namespace kOS.AddOns.KerbalAlarmClock
                 }
                 else
                 {
-                    ReturnValue = string.Empty;
+                    ReturnValue = StringValue(string.Empty);
                     SafeHouse.Logger.Log(string.Format("Failed creating KAC Alarm, UT={0}, Name={1}, Type= {2}", alarmUT, alarmName, alarmType));
                 }
             }
             else
             {
                 //KAC integration not present.
-                ReturnValue = string.Empty;
+                ReturnValue = StringValue(string.Empty);
                 throw new KOSUnavailableAddonException("addAlarm()", "Kerbal Alarm Clock");
             }
         }

--- a/src/kOS/Function/FunctionBase.cs
+++ b/src/kOS/Function/FunctionBase.cs
@@ -35,7 +35,7 @@ namespace kOS.Function
                 internalReturn = value;
             }
         }
-        private object internalReturn = null;
+        private object internalReturn = 0; // really should be 'null', but kerboscript can't deal with that.
         
         /// <summary>
         /// In the *extremely* rare case where a built-in function is NOT supposed to
@@ -212,6 +212,17 @@ namespace kOS.Function
             if (returnValue != null && returnValue.GetType() == OpcodeCall.ArgMarkerType)
                 throw new KOSArgumentMismatchException("Too few arguments were passed to " + GetFuncName());
             return returnValue;
+        }
+
+        /// <summary>
+        /// Identical to PopValueAssert, but with the additional step of coercing the result
+        /// into a Structure to be sure, so it won't return primitives.
+        /// </summary>
+        /// <returns>value after coercion into a kOS Structure</returns>
+        protected Structure PopValueAssertEncapsulated(SharedObjects shared, bool barewordOkay = false)
+        {
+            object returnValue = PopValueAssert(shared, barewordOkay);
+            return Structure.FromPrimitive(returnValue);
         }
         
         protected string GetFuncName()

--- a/src/kOS/Function/Math.cs
+++ b/src/kOS/Function/Math.cs
@@ -3,6 +3,7 @@ using kOS.Safe.Compilation;
 using kOS.Safe.Function;
 using kOS.Suffixed;
 using kOS.Safe.Exceptions;
+using kOS.Safe.Encapsulation;
 
 namespace kOS.Function
 {
@@ -14,7 +15,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = Math.Abs(argument);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -27,7 +28,7 @@ namespace kOS.Function
             double dividend = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = dividend % divisor;
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -39,7 +40,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = Math.Floor(argument);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -51,7 +52,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = Math.Ceiling(argument);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -78,7 +79,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = Math.Round(argument, decimals);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -90,7 +91,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = Math.Sqrt(argument);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -103,7 +104,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = Math.Log(argument);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -115,7 +116,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = Math.Log10(argument);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -131,7 +132,7 @@ namespace kOS.Function
             var pair = new OperandPair(argument1, argument2);
             Calculator calculator = Calculator.GetCalculator(pair);
             object result = calculator.Min(pair);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -147,7 +148,7 @@ namespace kOS.Function
             var pair = new OperandPair(argument1, argument2);
             Calculator calculator = Calculator.GetCalculator(pair);
             object result = calculator.Max(pair);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -159,7 +160,7 @@ namespace kOS.Function
         public override void Execute(SharedObjects shared)
         {
             AssertArgBottomAndConsume(shared);
-            ReturnValue = random.NextDouble();
+            ReturnValue = Structure.FromPrimitive(random.NextDouble());
         }
     }
 
@@ -194,7 +195,7 @@ namespace kOS.Function
             if (vector1 != null && vector2 != null)
             {
                 object result = Vector3d.Dot(vector1, vector2);
-                ReturnValue = result;
+                ReturnValue = Structure.FromPrimitive(result);
             }
             else
                 throw new KOSException("vector dot product attempted with a non-vector value");
@@ -232,7 +233,7 @@ namespace kOS.Function
             if (vector1 != null && vector2 != null)
             {
                 object result = Vector3d.Angle(vector1, vector2);
-                ReturnValue = result;
+                ReturnValue = Structure.FromPrimitive(result);
             }
             else
                 throw new KOSException("vector angle calculation attempted with a non-vector value");
@@ -248,7 +249,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             string result = new string((char) argument, 1);
-            ReturnValue = result;
+            ReturnValue = StringValue(result);
         }
     }
 
@@ -259,8 +260,8 @@ namespace kOS.Function
         {
             string argument = PopValueAssert(shared).ToString();
             AssertArgBottomAndConsume(shared);
-            double result = (double) argument.ToCharArray()[0];
-            ReturnValue = result;
+            char result = argument.ToCharArray()[0];
+            ReturnValue = ScalarIntValue((int)result);
         }
     }
 }

--- a/src/kOS/Function/Misc.cs
+++ b/src/kOS/Function/Misc.cs
@@ -44,9 +44,9 @@ namespace kOS.Function
         {
             bool      echo      = Convert.ToBoolean(PopValueAssert(shared));
             RgbaColor rgba      = GetRgba(PopValueAssert(shared));
-            int       size      = Convert.ToInt32 (PopValueAssert(shared));
-            int       style     = Convert.ToInt32 (PopValueAssert(shared));
-            int       delay     = Convert.ToInt32 (PopValueAssert(shared));
+            int       size      = Convert.ToInt32(PopValueAssert(shared));
+            int       style     = Convert.ToInt32(PopValueAssert(shared));
+            int       delay     = Convert.ToInt32(PopValueAssert(shared));
             string    textToHud = PopValueAssert(shared).ToString();
             AssertArgBottomAndConsume(shared);
             string htmlColour = rgba.ToHexNotation();

--- a/src/kOS/Function/Suffixed.cs
+++ b/src/kOS/Function/Suffixed.cs
@@ -188,9 +188,9 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            object[] argArray = new object[CountRemainingArgs(shared)];
+            Structure[] argArray = new Structure[CountRemainingArgs(shared)];
             for (int i = argArray.Length - 1 ; i >= 0 ; --i)
-                argArray[i] = PopValueAssert(shared); // fill array in reverse order because .. stack args.
+                argArray[i] = PopValueAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
             AssertArgBottomAndConsume(shared);
             var listValue = new ListValue(argArray.ToList());
             ReturnValue = listValue;
@@ -202,9 +202,9 @@ namespace kOS.Function
     {
         public override void Execute(SharedObjects shared)
         {
-            object[] argArray = new object[CountRemainingArgs(shared)];
+            Structure[] argArray = new Structure[CountRemainingArgs(shared)];
             for (int i = argArray.Length - 1 ; i >= 0 ; --i)
-                argArray[i] = PopValueAssert(shared); // fill array in reverse order because .. stack args.
+                argArray[i] = PopValueAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
             AssertArgBottomAndConsume(shared);
             var queueValue = new QueueValue(argArray.ToList());
             ReturnValue = queueValue;
@@ -218,7 +218,7 @@ namespace kOS.Function
         {
             object[] argArray = new object[CountRemainingArgs(shared)];
             for (int i = argArray.Length - 1 ; i >= 0 ; --i)
-                argArray[i] = PopValueAssert(shared); // fill array in reverse order because .. stack args.
+                argArray[i] = PopValueAssertEncapsulated(shared); // fill array in reverse order because .. stack args.
             AssertArgBottomAndConsume(shared);
             var stackValue = new StackValue(argArray.ToList());
             ReturnValue = stackValue;

--- a/src/kOS/Function/Trigonometry.cs
+++ b/src/kOS/Function/Trigonometry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using kOS.Safe.Function;
+using kOS.Safe.Encapsulation;
 
 namespace kOS.Function
 {
@@ -12,7 +13,7 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared);
             double radians = DegreesToRadians(degrees);
             double result = Math.Sin(radians);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -25,7 +26,7 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared);
             double radians = DegreesToRadians(degrees);
             double result = Math.Cos(radians);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -38,7 +39,7 @@ namespace kOS.Function
             AssertArgBottomAndConsume(shared);
             double radians = DegreesToRadians(degrees);
             double result = Math.Tan(radians);
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -50,7 +51,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = RadiansToDegrees(Math.Asin(argument));
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -62,7 +63,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = RadiansToDegrees(Math.Acos(argument));
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -74,7 +75,7 @@ namespace kOS.Function
             double argument = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = RadiansToDegrees(Math.Atan(argument));
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -87,7 +88,7 @@ namespace kOS.Function
             double y = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = RadiansToDegrees(Math.Atan2(y, x));
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 
@@ -100,7 +101,7 @@ namespace kOS.Function
             double ang1 = GetDouble(PopValueAssert(shared));
             AssertArgBottomAndConsume(shared);
             double result = kOS.Utilities.Utils.DegreeFix( ang2 - ang1, -180 );
-            ReturnValue = result;
+            ReturnValue = Structure.FromPrimitive(result);
         }
     }
 }


### PR DESCRIPTION
Okay, here's more edits for you.  I left the suffixes alone, and as a result I still don't know if all the stuff I edited properly compiles, because I don't know if the build process stopped before doing all the files.  (I got rid of all the errors I saw that I knew _weren't_ suffixes and were showing up in the list, but that isn't a guarantee that it ran all the way through.  I suspect it didn't build anything that depends on the files that failed.)

I finished Opcode.cs, and all the [Function("foo")]'s, and found a few small problems with the methods in the collections I had to clean up a bit to make them compile.  You definitely will want to merge those changes before going back to the suffixes as they will affect them.

I know for a fact that all the stuff using lexicons in kOS.Safe.Text will complain and not compile because of the restrictions we put in place making it impossible to make a collection of primitives or strings (they have to be collections of Structures now, which was the entire point of this refactor).  There's lots of code in there that tries to do things like this:

```
    lex["a"] = "aaa";
```

As opposed to the newly required way of:

```
    lex[new StringValue("a")] = new StringValue("aaa");
```

Although making that edit would make the kOS.Safe.Test cases a bit wordier, it does make them more in line with what would really happen when running the code for real, which is the point.  The end goal some day is to make all the test cases better by just allowing you to test actual kerboscript code rather than having to fake it like this.  Perhaps a set of convenience methods just for the tests could provide a wrapper around the wordiness without that wrapper being in the actual lexicon/listvalue/queuevalue/stackvalue classes.
